### PR TITLE
Menu bar can store documents

### DIFF
--- a/scenes/Document.tscn
+++ b/scenes/Document.tscn
@@ -4,7 +4,6 @@
 [ext_resource type="Script" path="res://scripts/document.gd" id="2_xaevp"]
 
 [node name="Dummy-letter" type="Sprite2D"]
-position = Vector2(71.25, 9)
 scale = Vector2(0.450588, 0.466667)
 texture = ExtResource("1_sp36h")
 script = ExtResource("2_xaevp")

--- a/scripts/document.gd
+++ b/scripts/document.gd
@@ -1,8 +1,9 @@
 extends Sprite2D
+
 var is_dragging = false;
 var mouse_offset;
 var delay = 1;
-
+var in_menu: bool = false;
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -11,7 +12,23 @@ func _ready():
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	pass
+	if in_menu and not $"../../DocumentMenu".expanded:
+		hide()
+		set_process_input(false)
+		is_dragging = false
+	else:
+		show()
+		set_process_input(true)
+	
+	if is_dragging and $"../../DocumentMenu".expanded:
+		verify_in_menu()
+
+
+func verify_in_menu():
+	var right = $"../../DocumentMenu".expanded_pos.x + $"../../DocumentMenu".width / 2
+	var top = $"../../DocumentMenu".expanded_pos.y + $"../../DocumentMenu".height / 2
+	var bottom = $"../../DocumentMenu".expanded_pos.y - $"../../DocumentMenu".height / 2
+	in_menu = position.x < right and position.y < top and position.y > bottom
 
 
 func process_dragging(delta):
@@ -25,7 +42,7 @@ func process_dragging(delta):
 		);
 		return true;
 	return false;
-	
+
 
 func _input(event):
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
@@ -35,3 +52,4 @@ func _input(event):
 				mouse_offset = get_global_mouse_position() - global_position;
 		else:
 			is_dragging = false;
+	

--- a/scripts/document_menu.gd
+++ b/scripts/document_menu.gd
@@ -2,8 +2,12 @@ extends Area2D
 
 signal expand_button_pressed()
 
+const menu_z = 50
+
 var retracted_pos: Vector2 = Vector2.ZERO
 var expanded_pos: Vector2 = Vector2.ZERO
+var width: int = 0
+var height: int = 0
 var expanded: bool = false
 
 var documents: Array = []
@@ -11,11 +15,13 @@ var documents: Array = []
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	var viewport_width = get_viewport().size.x
-	var sprite_width = $Sprite2D.texture.get_width()
+	width = $Sprite2D.texture.get_width()
+	height = $Sprite2D.texture.get_height()
 	var peek = 0.02 * viewport_width
-	retracted_pos = Vector2(-viewport_width / 2 - sprite_width / 2 + peek, 0)
-	expanded_pos = retracted_pos + Vector2(sprite_width - peek, 0)
+	retracted_pos = Vector2(-viewport_width / 2 - width / 2 + peek, 0)
+	expanded_pos = retracted_pos + Vector2(width - peek, 0)
 	position = retracted_pos
+	z_index = menu_z
 
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.

--- a/scripts/documents_handler.gd
+++ b/scripts/documents_handler.gd
@@ -23,7 +23,8 @@ func _process(delta):
 			document_ordering.push_front(doc);
 			refresh_z_indeces();
 			break
-	pass
+	refresh_z_indeces();
+
 
 # Set z index of all documents based on document ordering
 func refresh_z_indeces():
@@ -32,3 +33,5 @@ func refresh_z_indeces():
 		# Higher z index is closer to screen
 		var doc: Sprite2D = document_ordering[i];
 		doc.z_index = DOCUMENT_Z + max_z - i - 1;
+		if doc.in_menu or (i == 0 and doc.is_dragging):
+			doc.z_index += $"../DocumentMenu".menu_z

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -12,7 +12,6 @@ func _process(delta):
 
 func _on_document_menu_expand_button_pressed():
 	if $DocumentMenu.expanded:
-		print("debug")
 		$DocumentMenu.position = $DocumentMenu.retracted_pos;
 	else:
 		$DocumentMenu.position = $DocumentMenu.expanded_pos;


### PR DESCRIPTION
After a doc is stored inside the menu bar, collapsing the bar will hide the document. Reopening the bar allows you to take the document back out.